### PR TITLE
Fix mido tests due to changes in tempest framework

### DIFF
--- a/tempest/scenario/manager.py
+++ b/tempest/scenario/manager.py
@@ -621,8 +621,7 @@ class NetworkScenarioTest(ScenarioTest):
                 network_id=network.id,
                 tenant_id=network.tenant_id,
                 cidr=str_cidr,
-                ip_version=ip_version,
-                **kwargs
+                ip_version=ip_version
             )
             subnet.update(**kwargs)
             try:

--- a/tempest/scenario/midokura/manager.py
+++ b/tempest/scenario/midokura/manager.py
@@ -83,8 +83,8 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         port_id = self._get_custom_server_port_id(server,
                                                   ip_addr=server_ip)
         floating_ip = self.create_floating_ip(server,
-                                               public_network_id,
-                                               port_id=port_id)
+                                              public_network_id,
+                                              port_id=port_id)
         return floating_ip
 
     def _create_server(self, name, networks,
@@ -110,8 +110,8 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         if has_FIP:
             network_names = self._get_network_by_name(networks[0]['name'])
             FIP = self._assign_floating_ip(
-                   server=server,
-                   network_name=network_names[0]['name'])
+                server=server,
+                network_name=network_names[0]['name'])
 
         return dict(server=server, keypair=keypair, FIP=FIP)
 
@@ -173,7 +173,7 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
                     is not 'up\n':
                 try:
                     result = access_point_ssh.exec_command(
-                        "sudo /sbin/cirros-dhcpc up eth{0}".format(net), 
+                        "sudo /sbin/cirros-dhcpc up eth{0}".format(net),
                         10)
                     LOG.info(result)
                 except exceptions.TimeoutException:
@@ -220,8 +220,9 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         _creds = None
         _tenant = TA.get_tenant_by_name(tenant['name'])
         if _tenant is None:
-            _tenant, _creds  = TA.tenant_create_enabled(name=tenant['name'],
-                                              desc=tenant['description'])
+            _tenant, _creds = TA.tenant_create_enabled(
+                name=tenant['name'],
+                desc=tenant['description'])
         else:
             _creds = TA.admin_credentials(_tenant)
         return _tenant, _creds
@@ -230,21 +231,21 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         if not tenant:
             tenant = self.tenant_id
         client = self.network_client
-        _, sgs = client.list_security_groups(tenant_id=tenant)
+        sgs = client.list_security_groups(tenant_id=tenant)
         return sgs['security_groups']
 
     def _get_tenant_networks(self, tenant=None):
         if not tenant:
             tenant = self.tenant_id
         client = self.network_client
-        _, nets = client.list_networks(tenant_id=tenant)
+        nets = client.list_networks(tenant_id=tenant)
         return nets['networks']
 
     def _get_tenant_routers(self, tenant=None):
         if not tenant:
             tenant = self.tenant_id
         client = self.network_client
-        _, routers = client.list_routers(tenant_id=tenant)
+        routers = client.list_routers(tenant_id=tenant)
         return routers['routers']
 
     def _get_custom_server_port_id(self, server, ip_addr=None):
@@ -261,7 +262,7 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         routers = self._get_tenant_routers()
         d_router = filter(lambda x: x['name'].startswith(r_name), routers)[0]
         return net_resources.DeletableRouter(**d_router)
-    
+
     def _get_network_by_name(self, net_name):
         nets = self._get_tenant_networks(tenant=self.tenant_id)
         return filter(lambda x: x['name'].startswith(net_name), nets)
@@ -285,17 +286,19 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         self.network_client = self.mymanager.network_client
 
     def _toggle_dhcp(self, subnet_id, enable=False):
-        _, result = self.network_client.update_subnet(subnet_id, enable_dhcp=enable)
+        result = self.network_client.update_subnet(subnet_id,
+                                                   enable_dhcp=enable)
         subnet = result["subnet"]
         self.assertEqual(subnet["enable_dhcp"], enable)
         LOG.debug(result)
-    
+
     def _ping_through_gateway(self, hops, destination, should_succed=True):
         LOG.info("Trying to ping between %s and %s"
                  % (hops[-1][0], destination[0]))
         ssh_client = self.setup_tunnel(hops)
-        self.assertTrue(self._check_remote_connectivity(
-             ssh_client, destination[0], should_succed))
+        self.assertTrue(self._check_remote_connectivity(ssh_client,
+                                                        destination[0],
+                                                        should_succed))
 
     def _ssh_through_gateway(self, origin, destination):
         try:
@@ -310,12 +313,12 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         except Exception as inst:
             LOG.info(inst.args)
             raise
-    
+
     def _locate_file(self, path):
         realpath = os.getcwd()
         for root, dirs, _ in os.walk(realpath):
             if path in dirs:
-                return os.path.join(root,path)
+                return os.path.join(root, path)
     """
     YAML parsing methods
     """
@@ -331,20 +334,20 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
                 routers = []
                 for router in subnet['routers']:
                     router_names = [r['name'] for r in
-                                   self._get_tenant_routers()]
+                                    self._get_tenant_routers()]
                     if not any(map(lambda x: router['name'] in x,
-                        router_names)):
+                               router_names)):
                         if router['public']:
                             router = self._get_router(
-                                        client=self.network_client,
-                                        tenant_id=self.tenant_id)
+                                client=self.network_client,
+                                tenant_id=self.tenant_id)
                         else:
                             router = self._create_router(
-                                        namestart=router['name'],
-                                        tenant_id=self.tenant_id)
+                                namestart=router['name'],
+                                tenant_id=self.tenant_id)
                     else:
                         router = \
-                        self._get_tenant_router_by_name(router['name'])
+                            self._get_tenant_router_by_name(router['name'])
                     routers.append(router)
                 subnet_dic = \
                     dict(
@@ -364,13 +367,16 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
         for secgroup in topology['security_groups']:
             sgroups = self._get_tenant_security_groups(self.tenant_id)
             if secgroup['name'] in [r['name'] for r in sgroups]:
-                sg = filter(lambda x: x['name'].startswith(secgroup['name']), sgroups)[0]
+                sg = filter(
+                    lambda x: x['name'].startswith(secgroup['name']),
+                    sgroups)[0]
             else:
-                sg = self._create_empty_security_group(tenant_id=self.tenant_id,
-                                                       namestart=secgroup['name'])
-                rules = \
-                    self._create_security_group_rule_list(rule_dict=secgroup,
-                                                          secgroup=sg)
+                sg = self._create_empty_security_group(
+                    tenant_id=self.tenant_id,
+                    namestart=secgroup['name'])
+                self._create_security_group_rule_list(
+                    rule_dict=secgroup,
+                    secgroup=sg)
         test_topology = []
         for server in topology['servers']:
             s_nets = []
@@ -381,10 +387,12 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
                 s_sg.append(self._get_security_group_by_name(sg['name']))
             for x in range(server['quantity']):
                 name = data_utils.rand_name('server-smoke-')
-                test_topology.append(self._create_server(name=name,
-                                                         networks=s_nets,
-                                                         security_groups=s_sg,
-                                                         has_FIP=server['floating_ip']))
+                s_server = self._create_server(name=name,
+                                               networks=s_nets,
+                                               security_groups=s_sg,
+                                               has_FIP=server['floating_ip'])
+                test_topology.append(s_server)
+
         if 'gateway' in topology.keys() and topology['gateway']:
             test_topology.append(self.build_gateway(self.tenant_id))
 
@@ -400,8 +408,8 @@ class AdvancedNetworkScenarioTest(manager.NetworkScenarioTest):
                 for tenant in topology['tenants']:
                     _tenant, creds = self._get_tenant(tenant)
                     self.set_context(creds)
-                    topo =  [x for x in topology['scenarios'] \
-                                 if x['name'] == tenant['scenario']][0]
+                    topo = [x for x in topology['scenarios']
+                            if x['name'] == tenant['scenario']][0]
                     scenario.append(dict(credentials=creds,
                                          servers_and_keys=self._setup_topology(
                                              topo,

--- a/tempest/scenario/midokura/midotools/admintools.py
+++ b/tempest/scenario/midokura/midotools/admintools.py
@@ -33,15 +33,15 @@ class TenantAdmin(object):
             name = data_utils.rand_name(name='tenant-')
         if not desc:
             desc = data_utils.rand_name('desc_')
-        resp, tenant = self.client.create_tenant(
+        tenant = self.client.create_tenant(
             name=name,
             description=desc,
             enabled=True)
         user = self.get_user_by_name('admin')
         role = self.get_role_by_name('admin')
-        _, role = self.client.assign_user_role(tenant['id'],
-                                               user['id'],
-                                               role['id'])
+        self.client.assign_user_role(tenant['id'],
+                                     user['id'],
+                                     role['id'])
         creds = self._get_credentials(user, tenant)
         self.tenants.append(tenant)
         return tenant, creds
@@ -57,13 +57,13 @@ class TenantAdmin(object):
             password=self.client.password)
 
     def get_user_by_name(self, name):
-        _, users = self.client.get_users()
+        users = self.client.get_users()
         user = [u for u in users if u['name'] == name]
         if len(user) > 0:
             return user[0]
 
     def get_role_by_name(self, name):
-        _, roles = self.client.list_roles()
+        roles = self.client.list_roles()
         role = [r for r in roles if r['name'] == name]
         if len(role) > 0:
             return role[0]

--- a/tempest/scenario/midokura/midotools/helper.py
+++ b/tempest/scenario/midokura/midotools/helper.py
@@ -92,5 +92,4 @@ class Routetable:
             r = Routetable(line)
             if r.destination:
                 rtable.append(r)
-
         return rtable

--- a/tempest/scenario/midokura/midotools/scenario.py
+++ b/tempest/scenario/midokura/midotools/scenario.py
@@ -72,7 +72,7 @@ class TestScenario(manager.NetworkScenarioTest):
         self.subnets = []
         self.routers = []
         # saving the internal routers in a different list
-        self.internal_routers= []
+        self.internal_routers = []
         self.floating_ips = {}
         self.servers = {}
         self.masterkey = None
@@ -159,17 +159,18 @@ class TestScenario(manager.NetworkScenarioTest):
                 for r in mysubnet['routers']:
                     if not self.internal_routers or not \
                             all(map(lambda x: True if r["name"] in
-                                    x.values() else False, self.internal_routers)):
+                                x.values() else False, self.internal_routers)):
                         if r["public"]:
                             myrouter = self._get_router(mynetwork['tenant_id'])
                         else:
-                            myrouter = \
-                                self._create_custom_router(mynetwork['tenant_id'], name=r["name"])
+                            myrouter = self._create_custom_router(
+                                mynetwork['tenant_id'],
+                                name=r["name"])
                         self.internal_routers.append(myrouter)
                     else:
                         # should have a hit
-                        myrouter = \
-                            [rr for rr in self.internal_routers if rr["name"] in r["name"]][0]
+                        myrouter = [rr for rr in self.internal_routers
+                                    if rr["name"] in r["name"]][0]
                     routers.append(myrouter)
             # subnet needs to be created after the router or
             # the teardown process will fail
@@ -254,7 +255,7 @@ class TestScenario(manager.NetworkScenarioTest):
             if not is_overlapping_cidr:
                 raise
         self.assertIsNotNone(result,
-            'Unable to allocate tenant network')
+                             'Unable to allocate tenant network')
         subnet = net_common.DeletableSubnet(client=self.network_client,
                                             **result['subnet'])
         self.assertEqual(subnet.cidr, str(mysubnet['cidr']))
@@ -346,7 +347,7 @@ class TestScenario(manager.NetworkScenarioTest):
 
     def _toggle_dhcp(self, subnet_id, enable=False):
         subnet = {
-            "subnet":{
+            "subnet": {
                 "enable_dhcp": enable,
             }
         }

--- a/tempest/scenario/midokura/network_scenarios/scenario_basic_multitenant_fip.yaml
+++ b/tempest/scenario/midokura/network_scenarios/scenario_basic_multitenant_fip.yaml
@@ -11,10 +11,10 @@
 #    under the License.
 
 tenants:
-- name: tenant_1
+- name: tenantfip_1
   description: a tenant 
   scenario: scenario1
-- name: tenant_2
+- name: tenantfip_2
   description: a tenant 
   scenario: scenario1
 

--- a/tempest/scenario/midokura/test_network_advanced_security_groups.py
+++ b/tempest/scenario/midokura/test_network_advanced_security_groups.py
@@ -57,7 +57,8 @@ class TestNetworkAdvancedSecurityGroups(manager.AdvancedNetworkScenarioTest):
     def setUp(self):
         super(TestNetworkAdvancedSecurityGroups, self).setUp()
         self.servers_and_keys = self.setup_topology(
-            os.path.abspath('{0}scenario_advanced_security_groups.yaml'.format(SCPATH)))
+            os.path.abspath(
+                '{0}scenario_advanced_security_groups.yaml'.format(SCPATH)))
 
     @test.attr(type='smoke')
     @test.services('compute', 'network')
@@ -69,10 +70,10 @@ class TestNetworkAdvancedSecurityGroups(manager.AdvancedNetworkScenarioTest):
                     'port_range_max': None,
                     },
                     {
-                    'direction': 'ingress',
-                    'protocol': 'icmp',
-                    'port_range_min': 8,
-                    'port_range_max': None,
+                        'direction': 'ingress',
+                        'protocol': 'icmp',
+                        'port_range_min': 8,
+                        'port_range_max': None,
                     }]
         sg = self._get_security_group_by_name("sg")
         for rule in rulesets:

--- a/tempest/scenario/midokura/test_network_advanced_security_groups_2networks.py
+++ b/tempest/scenario/midokura/test_network_advanced_security_groups_2networks.py
@@ -67,10 +67,10 @@ class TestNetworkAdvancedSecurityGroups2Networks(
                     'port_range_min': 8,
                     'port_range_max': None, },
                     {
-                    'direction': 'ingress',
-                    'protocol': 'icmp',
-                    'port_range_min': 8,
-                    'port_range_max': None,
+                        'direction': 'ingress',
+                        'protocol': 'icmp',
+                        'port_range_min': 8,
+                        'port_range_max': None,
                     }]
         sg = self._get_security_group_by_name("sg")
         for rule in rulesets:

--- a/tempest/scenario/midokura/test_network_basic_adminstateup.py
+++ b/tempest/scenario/midokura/test_network_basic_adminstateup.py
@@ -34,7 +34,8 @@ class TestAdminStateUp(manager.AdvancedNetworkScenarioTest):
     def setUp(self):
         super(TestAdminStateUp, self).setUp()
         self.servers_and_keys = self.setup_topology(
-            os.path.abspath('{0}scenario_basic_adminstateup.yaml'.format(SCPATH)))
+            os.path.abspath(
+                '{0}scenario_basic_adminstateup.yaml'.format(SCPATH)))
 
     def _check_connection(self, should_connect=True):
         ssh_login = CONF.compute.image_ssh_user
@@ -97,4 +98,3 @@ class TestAdminStateUp(manager.AdvancedNetworkScenarioTest):
         self._check_vm_connectivity_port()
         self._check_connection(True)
         LOG.info("End of Port test")
-

--- a/tempest/scenario/midokura/test_network_basic_dhcp_disable.py
+++ b/tempest/scenario/midokura/test_network_basic_dhcp_disable.py
@@ -44,8 +44,9 @@ class TestNetworkBasicDhcpDisable(manager.AdvancedNetworkScenarioTest):
 
     def setUp(self):
         super(TestNetworkBasicDhcpDisable, self).setUp()
-        self.servers_and_keys = \
-            self.setup_topology(os.path.abspath('{0}scenario_basic_dhcp_disable.yaml'.format(SCPATH)))
+        self.servers_and_keys = self.setup_topology(
+            os.path.abspath(
+                '{0}scenario_basic_dhcp_disable.yaml'.format(SCPATH)))
 
     # this should be ported to "linux_client" class
     def _do_dhcp_lease(self, hops, timeout=0):
@@ -89,7 +90,7 @@ class TestNetworkBasicDhcpDisable(manager.AdvancedNetworkScenarioTest):
         ap = ap_details['server']
         networks = ap['addresses']
         hops = [(ap_details['FIP'].floating_ip_address,
-            ap_details['keypair']['private_key'])]
+                 ap_details['keypair']['private_key'])]
         #the last element is ignored since it is the gateway
         for element in self.servers_and_keys[:-1]:
             server = element['server']

--- a/tempest/scenario/midokura/test_network_basic_dhcp_lease.py
+++ b/tempest/scenario/midokura/test_network_basic_dhcp_lease.py
@@ -56,8 +56,8 @@ class TestNetworkBasicDhcpLease(manager.AdvancedNetworkScenarioTest):
 
     def setUp(self):
         super(TestNetworkBasicDhcpLease, self).setUp()
-        self.servers_and_keys = \
-            self.setup_topology(os.path.abspath('{0}scenario_basic_dhcp.yaml'.format(SCPATH)))
+        self.servers_and_keys = self.setup_topology(
+            os.path.abspath('{0}scenario_basic_dhcp.yaml'.format(SCPATH)))
 
     def _check_routes(self, hops):
         LOG.info("Obtaining the routes")
@@ -76,8 +76,9 @@ class TestNetworkBasicDhcpLease(manager.AdvancedNetworkScenarioTest):
         LOG.info("Obtaining the routes")
         try:
             ssh_client = self.setup_tunnel(hops)
-            dns = ssh_client.exec_command("cat /etc/resolv.conf | grep nameserver | "
-                                          "awk '{print $2}'").replace("\n", "")
+            dns = ssh_client.exec_command(
+                "cat /etc/resolv.conf | grep nameserver | "
+                "awk '{print $2}'").replace("\n", "")
             LOG.info(dns)
             self.assertEqual(dns, "8.8.8.8")
         except Exception as inst:
@@ -100,7 +101,8 @@ class TestNetworkBasicDhcpLease(manager.AdvancedNetworkScenarioTest):
         ap_details = self.servers_and_keys[-1]
         ap = ap_details['server']
         networks = ap['addresses']
-        hops = [(ap_details['FIP'].floating_ip_address, ap_details['keypair']['private_key'])]
+        hops = [(ap_details['FIP'].floating_ip_address,
+                 ap_details['keypair']['private_key'])]
         # the last element is ignored since it is the gateway
         for element in self.servers_and_keys[:-1]:
             server = element['server']
@@ -135,7 +137,7 @@ class TestNetworkBasicDhcpLease(manager.AdvancedNetworkScenarioTest):
     def test_network_basic_dhcp_lease_full(self):
         self._do_test()
         LOG.info("test full finished, tearing down now ....")
-    
+
     @test.attr(type='smoke')
     @test.services('compute', 'network')
     def test_network_basic_dhcp_lease_dns(self):

--- a/tempest/scenario/midokura/test_network_basic_inter_vmconnectivity.py
+++ b/tempest/scenario/midokura/test_network_basic_inter_vmconnectivity.py
@@ -50,16 +50,17 @@ class TestNetworkBasicInterVMConnectivity(manager.AdvancedNetworkScenarioTest):
     def setUp(self):
         super(TestNetworkBasicInterVMConnectivity, self).setUp()
         self.servers_and_keys = self.setup_topology(
-                os.path.abspath('{0}scenario_basic_inter_vmconnectivity.yaml'.format(SCPATH)))
-        
-   
+            os.path.abspath(
+                '{0}scenario_basic_inter_vmconnectivity.yaml'.format(SCPATH)))
+
     @test.attr(type='smoke')
     @test.services('compute', 'network')
     def test_network_basic_inter_vmssh(self):
         ap_details = self.servers_and_keys[-1]
         ap = ap_details['server']
         networks = ap['addresses']
-        hops=[(ap_details['FIP'].floating_ip_address, ap_details['keypair']['private_key'])]
+        hops = [(ap_details['FIP'].floating_ip_address,
+                 ap_details['keypair']['private_key'])]
         ip_pk = []
         #the access_point server should be the last one in the list
         for element in self.servers_and_keys[:-1]:
@@ -75,7 +76,7 @@ class TestNetworkBasicInterVMConnectivity(manager.AdvancedNetworkScenarioTest):
                 LOG.info("FAIL - No ip connectivity to the server ip: %s"
                          % server['addresses'][name][0]['addr'])
                 raise Exception("FAIL - No ip for this network : %s"
-                            % server['addresses'][name])
+                                % server['addresses'][name])
         for pair in itertools.permutations(ip_pk):
             LOG.info("Checking ssh between %s %s"
                      % (pair[0][0], pair[1][0]))

--- a/tempest/scenario/midokura/test_network_basic_security_groups.py
+++ b/tempest/scenario/midokura/test_network_basic_security_groups.py
@@ -52,15 +52,18 @@ class TestNetworkBasicSecurityGroups(manager.AdvancedNetworkScenarioTest):
     def setUp(self):
         super(TestNetworkBasicSecurityGroups, self).setUp()
         self.servers_and_keys = self.setup_topology(
-            os.path.abspath('{0}scenario_basic_security_groups.yaml'.format(SCPATH)))
-        
+            os.path.abspath(
+                '{0}scenario_basic_security_groups.yaml'.format(SCPATH)))
+
     def _create_vm3_and_sg1(self):
         # creates the vm3 and assigns it sc "sg1"
         net = self._get_network_by_name('netA')
         sg = self._create_empty_security_group(tenant_id=self.tenant_id,
-                namestart="sg1")
-        server = self._create_server(name="vm3", networks=net,
-                 security_groups=[sg], has_FIP=False)['server']
+                                               namestart="sg1")
+        server = self._create_server(name="vm3",
+                                     networks=net,
+                                     security_groups=[sg],
+                                     has_FIP=False)['server']
         return server
 
     @test.attr(type='smoke')
@@ -70,8 +73,8 @@ class TestNetworkBasicSecurityGroups(manager.AdvancedNetworkScenarioTest):
         ap_details = self.servers_and_keys[-1]
         ap = ap_details['server']
         networks = ap['addresses']
-        hops=[(ap_details['FIP'].floating_ip_address,
-             ap_details['keypair']['private_key'])]
+        hops = [(ap_details['FIP'].floating_ip_address,
+                 ap_details['keypair']['private_key'])]
         ip_pk = []
         for element in self.servers_and_keys[:-1]:
             # servers should only have 1 network
@@ -85,7 +88,7 @@ class TestNetworkBasicSecurityGroups(manager.AdvancedNetworkScenarioTest):
                 LOG.info("FAIL - No ip connectivity to the server ip: %s"
                          % server['addresses'][name][0]['addr'])
                 raise Exception("FAIL - No ip for this network : %s"
-                            % server['addresses'][name])
+                                % server['addresses'][name])
         for pair in itertools.permutations(ip_pk):
             nhops = hops + [pair[0]]
             self._ssh_through_gateway(nhops, pair[1])
@@ -96,13 +99,13 @@ class TestNetworkBasicSecurityGroups(manager.AdvancedNetworkScenarioTest):
     @test.attr(type='smoke')
     @test.services('compute', 'network')
     def test_network_basic_multi_security_group(self):
-        vm3  = self._create_vm3_and_sg1()
+        vm3 = self._create_vm3_and_sg1()
         # we get the access point server
         ap_details = self.servers_and_keys[-1]
         ap = ap_details['server']
         networks = ap['addresses']
-        hops=[(ap_details['FIP'].floating_ip_address,
-             ap_details['keypair']['private_key'])]
+        hops = [(ap_details['FIP'].floating_ip_address,
+                 ap_details['keypair']['private_key'])]
         server = self.servers_and_keys[0]['server']
         name = server['addresses'].keys()[0]
         if any(i in networks.keys() for i in server['addresses'].keys()):
@@ -111,9 +114,9 @@ class TestNetworkBasicSecurityGroups(manager.AdvancedNetworkScenarioTest):
             nhops = hops + [(remote_ip, pk)]
         else:
             LOG.info("FAIL - No ip connectivity to the server ip: %s"
-                         % server['addresse'][name][0]['addr'])
+                     % server['addresses'][name][0]['addr'])
             raise Exception("FAIL - No ip for this network : %s"
                             % server['addresses'][name])
         self._ping_through_gateway(nhops,
-                    vm3['addresses'].values()[0], 
-                    should_succed=False)
+                                   vm3['addresses'].values()[0][0]['addr'],
+                                   should_succed=False)

--- a/tempest/scenario/midokura/test_network_basic_security_groups_2networks.py
+++ b/tempest/scenario/midokura/test_network_basic_security_groups_2networks.py
@@ -67,10 +67,10 @@ class TestNetworkAdvancedSecurityGroups2Networks(
                     'port_range_min': 8,
                     'port_range_max': None, },
                     {
-                    'direction': 'ingress',
-                    'protocol': 'icmp',
-                    'port_range_min': 8,
-                    'port_range_max': None,
+                        'direction': 'ingress',
+                        'protocol': 'icmp',
+                        'port_range_min': 8,
+                        'port_range_max': None,
                     }]
         sg = self._get_security_group_by_name("sg")
         for rule in rulesets:

--- a/tempest/scenario/midokura/test_network_basic_security_groups_netcat.py
+++ b/tempest/scenario/midokura/test_network_basic_security_groups_netcat.py
@@ -83,7 +83,6 @@ class TestNetworkBasicSecurityGroupsNetcat(
         LOG.info(result)
         self.assertEqual("123\n", result)
 
-
     @test.attr(type='smoke')
     @test.services('compute', 'network')
     def test_network_basic_netcat_udp(self):


### PR DESCRIPTION
- Various fixes to comply with latest changes in tempest.
- Fixed concurrent execution of multitenant and multitenant_fip
- PEP8 compliance.
- UPSTREAM: tempest manager. When creating subnets, kwargs shouldn't be
  added initially to the dict but later updated.
